### PR TITLE
Allow setting peer

### DIFF
--- a/src/cowboy_gen.erl
+++ b/src/cowboy_gen.erl
@@ -33,7 +33,7 @@ req(Props) ->
 req(Props, CowboyVersion) ->
     Socket = undefined,
     Transport = cowboy_gen,
-    Peer = undefined,
+    Peer = proplists:get_value(peer, Props, default_peer(CowboyVersion)),
     Method = proplists:get_value(method, Props, <<"GET">>),
     Path = <<>>,
     Query = <<>>,
@@ -52,6 +52,13 @@ req(Props, CowboyVersion) ->
               Buffer, CanKeepalive, Compress, OnResponse),
     QsVals = proplists:get_value(qs_vals, Props, []),
     cowboy_req:set([{qs_vals, QsVals}], Req).
+
+-spec default_peer(version()) ->
+    undefined | {inet:ip_address(), inet:port_number()}.
+default_peer(Version) when Version >= {0, 8, 5} ->
+    {{0,0,0,0}, 0};
+default_peer(_Version) ->
+    undefined.
 
 -spec set_version(version()) -> 'HTTP/1.1' | {1, 1}.
 set_version(Version) ->


### PR DESCRIPTION
Props can now contain a `peer` field. A default value for `peer` is
set depending on the cowboy version.

Cowboy 0.8.5 changed the spec of `cowboy_req:peer` from

```
-spec peer(Req) -> {undefined | {inet:ip_address(), inet:port_number()}, Req}.
```

to

```
-spec peer(Req) -> {{inet:ip_address(), inet:port_number()}, Req}.
```

making the `peer` field obligatory.
